### PR TITLE
[createIndex] roll past when index patterns do not exist

### DIFF
--- a/_createIndex.js
+++ b/_createIndex.js
@@ -143,9 +143,11 @@ module.exports = function createIndex() {
       console.log('clearing existing "%s" index templates and indices', indexTemplate);
       return Promise.all([
         client.indices.deleteTemplate({
+          ignore: 404,
           name: indexTemplateName
         }),
         client.indices.delete({
+          ignore: 404,
           index: indexTemplate
         })
       ]);


### PR DESCRIPTION
makelogs dies if the index templates don't magically exist.

```
$ makelogs -c 40k -d 8 --auth=admin:admin
Generating 40000 events from 2016-01-03T00:00:00+00:00 to 2016-01-19T23:59:59+00:00
? Existing logstash-* indices and/or index templates were found, can they be replaced? Yes
clearing existing "logstash-*" index templates and indices
Error: [index_template_missing_exception] index_template [makelogs_index_template__logstash-] missing
    at respond (/Users/d33t/.nvm/versions/node/v0.12.9/lib/node_modules/makelogs/node_modules/elasticsearch/src/lib/transport.js:256:15)
    at checkRespForFailure (/Users/d33t/.nvm/versions/node/v0.12.9/lib/node_modules/makelogs/node_modules/elasticsearch/src/lib/transport.js:219:7)
    at HttpConnector.<anonymous> (/Users/d33t/.nvm/versions/node/v0.12.9/lib/node_modules/makelogs/node_modules/elasticsearch/src/lib/connectors/http.js:155:7)
    at IncomingMessage.wrapper (/Users/d33t/.nvm/versions/node/v0.12.9/lib/node_modules/makelogs/node_modules/elasticsearch/node_modules/lodash/index.js:3095:19)
    at IncomingMessage.emit (events.js:129:20)
    at _stream_readable.js:908:16
    at process._tickCallback (node.js:355:11)
```