### PR TITLE
Make makelogs default mappings ES 3.0 compatible

### DIFF
--- a/_createIndex.js
+++ b/_createIndex.js
@@ -65,7 +65,7 @@ module.exports = function createIndex() {
           },
           id: {
             type: 'integer',
-            index: 'not_analyzed',
+            index: 'true',
             include_in_all: false
           },
           clientip: {
@@ -116,7 +116,7 @@ module.exports = function createIndex() {
                   },
                   lastname: {
                     type: 'integer',
-                    index: 'not_analyzed'
+                    index: 'true'
                   }
                 }
               }


### PR DESCRIPTION
ES 3.0 no longer accepts not_analyzed/no as values for the index
property of non-string mappings.

Read more here:
https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking_30_mapping_changes.html